### PR TITLE
show search bar again

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -70,6 +70,7 @@ button {
 
 #bigmap {
 	position: absolute;
+	margin-top: 50px;
 	width: 100%;
 	height: 100%;
 }


### PR DESCRIPTION
Somehow the map goes full screen and hides the search bar. This makes it slightly better, but it doesn't fully solve the problem, since there are some pixels overlapping. But at least the search can be used again.